### PR TITLE
DBAAS-4794: SqlAlchemy converts BOOLEAN type to SMALLINT type when using ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ string for accessing it
 cd /path/to/splice_sqlalchemy
 sudo pip install .
 sudo pip install pytest
-py.test -vv --db-url 'splicemachinesa://[...]'
+pytest -vv --db-url 'splicemachinesa://[...]'
 ```
 
 #### Features not yet supported

--- a/splicemachinesa/base.py
+++ b/splicemachinesa/base.py
@@ -105,47 +105,6 @@ class _SM_String(sa_types.String):
         return process
 
 
-class _SM_Boolean(sa_types.Boolean):
-    """
-    An overrided boolean class specifically
-    for Splice Machine that converts Boolean
-    SQLAlchemy types into TINYINT (0/1) values
-    """
-
-    def result_processor(self, dialect, coltype):
-        """
-        Return a conversion function for
-        processing row values
-        :param dialect: the current dialect in use
-        :param coltype: the column type in DB Schema
-            from pyODBC.connection.cursor.description
-
-        :returns: func for parsing boolean value of integer
-        """
-
-        def process(value):
-            if value is None:  # null
-                return None
-            else:  # bool(0) -> false, bool(1) -> true
-                return bool(value)
-
-        return process
-
-    def bind_processor(self, dialect):
-        """
-        Return a conversion function for processing bind values
-        (when sending, rather than receiving)
-        :param dialect: the current dialect in use
-        :returns: func for getting
-            integer value from boolean specified
-        """
-
-        def process(value):
-            return None if value is None else int(bool(value))
-
-        return process
-
-
 class _SM_Date(sa_types.Date):
     """
     An overrided date class specifically
@@ -197,7 +156,6 @@ class _SM_Date(sa_types.Date):
 # Mapping for our overrided functions to the original ones
 
 colspecs = {
-    sa_types.Boolean: _SM_Boolean,
     sa_types.Date: _SM_Date,
     sa_types.DateTime: _SM_Date,
     sa_types.Integer: _SM_Integer,
@@ -547,9 +505,7 @@ class SpliceMachineTypeCompiler(compiler.GenericTypeCompiler):
             specified by the user
         :returns: data type rendering
         """
-        return self.visit_SMALLINT(type_)
-        # boolean are stored as smallints in
-        # database
+        return self.visit_BOOLEAN(type_)
 
     def visit_float(self, type_):
         """
@@ -1175,7 +1131,7 @@ class SpliceMachineDialect(default.DefaultDialect):
     supports_sane_rowcount = True
     supports_sane_multi_rowcount = True
     supports_native_decimal = False
-    supports_native_boolean = False
+    supports_native_boolean = True
     preexecute_sequences = False
     supports_alter = True
     supports_sequences = True


### PR DESCRIPTION
SQLAlchemy Adapter was converting all boolean values to SMALLINTs and storing them as such in corresponding tables. This PR removes the overriding Boolean class that did this, and uses the native SQLAlchemy boolean instead. Additionally, it tells SQLAlchemy that we support native booleans, so it does not create a check for integer values.