### PR TITLE
support tinyint in reflection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ and are licensed to you under the GNU Affero General Public License.
 """
 
 
-VERSION = '0.3.4'
+VERSION = '0.3.5'
 ODBC_VERSION = '2.8.73.0'
 
 def bash(command):

--- a/splicemachinesa/base.py
+++ b/splicemachinesa/base.py
@@ -203,7 +203,8 @@ ischema_names = {
     'TIMESTAMP': TIMESTAMP,
     'VARCHAR': VARCHAR,
     'LONGVARCHAR': LONGVARCHAR,
-    'TEXT': TEXT
+    'TEXT': TEXT,
+    'TINYINT':SMALLINT
 }
 
 


### PR DESCRIPTION
Adding support for tinyint in reflection. Without this, it would return NULL, but now it returns smallint which works for most cases as sqlalchemy doesn't have a tinyint type.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
