### PR TITLE
DBAAS-5192: get_table_names not showing external tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ and are licensed to you under the GNU Affero General Public License.
 """
 
 
-VERSION = '0.3.7'
+VERSION = '0.3.8'
 ODBC_VERSION = '2.8.73.0'
 
 def bash(command):

--- a/splicemachinesa/reflection.py
+++ b/splicemachinesa/reflection.py
@@ -204,7 +204,7 @@ class SMReflector(BaseReflector):
 
         query = """
         SELECT TABLENAME FROM {systable}
-        WHERE TABLETYPE='T' AND 
+        WHERE (TABLETYPE='T' OR TABLE_TYPE='E') AND 
         SCHEMAID='{schemaid}'
         """.format(systable=self.capitalize(self.SYS_TABLE), schemaid=schema_id)
 


### PR DESCRIPTION
## Description
In online HUE viewer, we don’t see external tables. This is because we are checking for tables with `TABLETYPE=T` using 
`SELECT TABLENAME FROM SYS.SYSTABLES WHERE TABLETYPE='T'`

but should use add `TABLETYPE='E'` like this

`SELECT TABLENAME FROM SYS.SYSTABLES WHERE TABLETYPE='T' OR TABLETYPE='E';`

## How to test

Create an external table in SQL like this

`CREATE EXTERNAL TABLE MY_TEST_TABLE (i INTEGER) stored as parquet location '/tmp/testPath';`

Note: this will create the path `/tmp/testPath` . Online / real cluster: replace `/tmp/testPath` with something on s3 (s3a) or gc (gcs).

After creating successfully, we should see MY_TEST_TABLE in the get_table_names.