### PR TITLE
Add JWT support to splice_connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,18 @@ You can use this package for SqlAlchemy usage or raw ODBC usage
 #### ODBC Connection Only (Basic Auth)
 ```
 from splicemachinesa.pyodbc import splice_connect
-ODBC_CONNECTION = splice_connect(URL=[URL], JWT_TOKEN=[JWT_TOKEN], JWT_TYPE=[JWT_TYPE], SSL=[SSL])
+ODBC_CONNECTION = splice_connect(URL=[URL], UID=[UID], PWD=[PWD], SSL=[SSL])
 ```
-Filling in `JWT_TOKEN`, `JWT_TYPE`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`<br>
-You must set the JWT_TYPE to use this format. Available options are ('SPLICE_JWT', 'SPLICE_JWT_PUB', 'OKTA_OAUTH', 'SPLICE_OAUTH')
+Filling in `UID`, `PWD`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`
+
 
 #### ODBC Connection Only (JWT Connection)
 ```
 from splicemachinesa.pyodbc import splice_connect
-ODBC_CONNECTION = splice_connect(URL=[URL], UID=[UID], PWD=[PWD], SSL=[SSL])
+ODBC_CONNECTION = splice_connect(URL=[URL], JWT_TOKEN=[JWT_TOKEN], JWT_TYPE=[JWT_TYPE], SSL=[SSL])
 ```
-Filling in `UID`, `PWD`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`
+Filling in `JWT_TOKEN`, `JWT_TYPE`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`<br>
+You must set the JWT_TYPE to use this format. Available options are ('SPLICE_JWT', 'SPLICE_JWT_PUB', 'OKTA_OAUTH', 'SPLICE_OAUTH')
 
 
 #### SqlAlchemy

--- a/README.md
+++ b/README.md
@@ -72,12 +72,21 @@ pip install splicemachinesa
 
 You can use this package for SqlAlchemy usage or raw ODBC usage
 
-#### ODBC Connection Only
+#### ODBC Connection Only (Basic Auth)
 ```
 from splicemachinesa.pyodbc import splice_connect
-ODBC_CONNECTION = splice_connect(UID=[UID], PWD=[PWD], URL=[URL], SSL=[SSL])
+ODBC_CONNECTION = splice_connect(URL=[URL], JWT_TOKEN=[JWT_TOKEN], JWT_TYPE=[JWT_TYPE], SSL=[SSL])
+```
+Filling in `JWT_TOKEN`, `JWT_TYPE`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`<br>
+You must set the JWT_TYPE to use this format. Available options are ('SPLICE_JWT', 'SPLICE_JWT_PUB', 'OKTA_OAUTH', 'SPLICE_OAUTH')
+
+#### ODBC Connection Only (JWT Connection)
+```
+from splicemachinesa.pyodbc import splice_connect
+ODBC_CONNECTION = splice_connect(URL=[URL], UID=[UID], PWD=[PWD], SSL=[SSL])
 ```
 Filling in `UID`, `PWD`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`
+
 
 #### SqlAlchemy
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ ODBC_CONNECTION = splice_connect(URL=[URL], UID=[UID], PWD=[PWD], SSL=[SSL])
 ```
 Filling in `UID`, `PWD`, `URL`, and `SSL` with the proper values for your database. SSL defaults to 'basic' If you are connecting to the Splice Database _inside_ the same network (ie standalone splice) you will set `SSL=None`
 
-
 #### ODBC Connection Only (JWT Connection)
 ```
 from splicemachinesa.pyodbc import splice_connect

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ and are licensed to you under the GNU Affero General Public License.
 """
 
 
-VERSION = '0.4.0'
+VERSION = '0.4.0dev2'
 ODBC_VERSION = '2.8.74.0'
 
 def bash(command):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ and are licensed to you under the GNU Affero General Public License.
 """
 
 
-VERSION = '0.4.0dev2'
+VERSION = '0.4.0'
 ODBC_VERSION = '2.8.74.0'
 
 def bash(command):

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ and are licensed to you under the GNU Affero General Public License.
 """
 
 
-VERSION = '0.3.9'
-ODBC_VERSION = '2.8.73.0'
+VERSION = '0.4.0'
+ODBC_VERSION = '2.8.74.0'
 
 def bash(command):
     run_bash(command.split())

--- a/splicemachinesa/pyodbc.py
+++ b/splicemachinesa/pyodbc.py
@@ -52,7 +52,7 @@ def splice_connect(URL,
     :param PORT: The datbase port [default 1527]
     :param SSL: The SSL level [default basic]
     :param Driver: The driver [if not provided, will use the one downloaded upon installation of splicemachinesa]
-    :return:
+    :return: ODBC Connection
     """
     Driver = Driver or DRIVER_LOCATIONS[system()]
     kwargs = dict(

--- a/splicemachinesa/pyodbc.py
+++ b/splicemachinesa/pyodbc.py
@@ -34,17 +34,21 @@ DRIVER_LOCATIONS = {
 }
 def splice_connect(URL,
                    UID=None, PWD=None,
-                   JWT_TOKEN=None,
+                   JWT_TOKEN=None, JWT_TYPE=None,
                    PORT='1527', SSL='basic', Driver=None):
     """
     A function that returns a raw ODBC connection to the provided Splice Database. This can be used with either basic
     auth or JWT authentication.
-    NOTE: If a JWT_TOKEN is provided, the JWT authentication will take precedence.
+    NOTE: If a JWT_TOKEN and JWT_TYPE are provided, the JWT authentication will take precedence.
+
+    To connect with basic auth you must set BOTH UID and PWD
+    To connect with JWT, you must set BOTH JWT_TOKEN and JWT_TYPE. Valid JWT_TYPEs are (SPLICE_JWT,SPLICE_JWT_PUB,OKTA_OAUTH,SPLICE_OAUTH)
 
     :param URL: The database JDBC Host
     :param UID: The User ID (if using basic auth)
     :param PWD: The User Password (if using basic auth)
     :param JWT_TOKEN: The JWT Token (if using JWT authentication)
+    :param JWT_TYPE: The JWT Type (if using JWT authentication). Valid options are (SPLICE_JWT,SPLICE_JWT_PUB,OKTA_OAUTH,SPLICE_OAUTH)
     :param PORT: The datbase port [default 1527]
     :param SSL: The SSL level [default basic]
     :param Driver: The driver [if not provided, will use the one downloaded upon installation of splicemachinesa]
@@ -57,9 +61,12 @@ def splice_connect(URL,
         UID=UID,PWD=PWD,
         PORT=PORT,SSL=SSL
     )
-    if JWT_TOKEN:
+    if JWT_TOKEN and not JWT_TYPE:
+        raise Exception('You cannot set JWT_TOKEN without setting a valid JWT_TYPE. Valid types are '
+                        '(SPLICE_JWT,SPLICE_JWT_PUB,OKTA_OAUTH,SPLICE_OAUTH)')
+    if JWT_TOKEN and JWT_TYPE:
         kwargs['JWT_TOKEN'] = JWT_TOKEN
-        kwargs['JWT_TYPE'] = 'SPLICE_OAUTH'
+        kwargs['JWT_TYPE'] = JWT_TYPE
 
     ODBC_CONNECTION = odbc_connect(**kwargs)
     return ODBC_CONNECTION

--- a/splicemachinesa/pyodbc.py
+++ b/splicemachinesa/pyodbc.py
@@ -32,9 +32,36 @@ DRIVER_LOCATIONS = {
     'Darwin': f'{HOME}/libsplice_odbc64.dylib',
     'Linux': f'{HOME}/libsplice_odbc.so'
 }
-def splice_connect(UID, PWD, URL, PORT='1527', SSL='basic', Driver=None):
+def splice_connect(URL,
+                   UID=None, PWD=None,
+                   JWT_TOKEN=None,
+                   PORT='1527', SSL='basic', Driver=None):
+    """
+    A function that returns a raw ODBC connection to the provided Splice Database. This can be used with either basic
+    auth or JWT authentication.
+    NOTE: If a JWT_TOKEN is provided, the JWT authentication will take precedence.
+
+    :param URL: The database JDBC Host
+    :param UID: The User ID (if using basic auth)
+    :param PWD: The User Password (if using basic auth)
+    :param JWT_TOKEN: The JWT Token (if using JWT authentication)
+    :param PORT: The datbase port [default 1527]
+    :param SSL: The SSL level [default basic]
+    :param Driver: The driver [if not provided, will use the one downloaded upon installation of splicemachinesa]
+    :return:
+    """
     Driver = Driver or DRIVER_LOCATIONS[system()]
-    ODBC_CONNECTION = odbc_connect(Driver=Driver,UID=UID,PWD=PWD,URL=URL,PORT=PORT,SSL=SSL)
+    kwargs = dict(
+        Driver=Driver,
+        URL=URL,
+        UID=UID,PWD=PWD,
+        PORT=PORT,SSL=SSL
+    )
+    if JWT_TOKEN:
+        kwargs['JWT_TOKEN'] = JWT_TOKEN
+        kwargs['JWT_TYPE'] = 'SPLICE_OAUTH'
+
+    ODBC_CONNECTION = odbc_connect(**kwargs)
     return ODBC_CONNECTION
 
 class SpliceMachineExecutionContext_pyodbc(_SelectLastRowIDMixin, SpliceMachineExecutionContext):


### PR DESCRIPTION
Add additional parameters and documentation to the `splice_connect` function to support connection via JWT

## Description
New parameters for JWT support. Supported JWT types are (SPLICE_JWT,SPLICE_JWT_PUB,OKTA_OAUTH,SPLICE_OAUTH)

## Motivation and Context
Splice SSO

## Dependencies
New ODBC driver

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/114217767-9874b080-9936-11eb-8e02-d6aeae84639b.png)


## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
JWT support for `splice_connect`

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
