### PR TITLE
fix for offset clause

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ and are licensed to you under the GNU Affero General Public License.
 """
 
 
-VERSION = '0.4.2'
+VERSION = '0.4.3'
 ODBC_VERSION = '2.8.77.0'
 
 def bash(command):

--- a/splicemachinesa/base.py
+++ b/splicemachinesa/base.py
@@ -658,10 +658,13 @@ class SpliceMachineCompiler(compiler.SQLCompiler):
         :param select: the select query class
         :returns: clause for limit
         """
-        if (select._limit is not None) and (select._offset is None):
-            return " FETCH FIRST %s ROWS ONLY" % select._limit  # get fetch first
-        else:
-            return ""
+        print(f'\n\nINFO: {select.__dict__}\n\n')
+        text = ''
+        if select._offset_clause is not None:
+            text += ' OFFSET %s ROWS' % select._offset
+        if select._limit_clause is not None:
+            text += " FETCH FIRST %s ROWS ONLY" % select._limit  # get fetch first
+        return text
 
     def visit_select(self, select, **kwargs):
         """

--- a/splicemachinesa/base.py
+++ b/splicemachinesa/base.py
@@ -658,7 +658,6 @@ class SpliceMachineCompiler(compiler.SQLCompiler):
         :param select: the select query class
         :returns: clause for limit
         """
-        print(f'\n\nINFO: {select.__dict__}\n\n')
         text = ''
         if select._offset_clause is not None:
             text += ' OFFSET %s ROWS' % select._offset


### PR DESCRIPTION
We weren't handling the `offset` clause in sqlalchemy, and there was a bug where if a user provided an offset and a limit, the limit wasn't used for some reason. 

## Description
Handling both limit and offset properly

## Motivation and Context
Bug fix

## Dependencies
None

## How Has This Been Tested?
Tested with limit, offset, both, and neither

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/124630798-c0e64b00-de50-11eb-95af-a428faadccaa.png)


## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes
* Limit and offset clause for sqlalchemy
### Deprecated

### Removed

### Breaking Changes
